### PR TITLE
fix: fixed build option

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ async function run() {
 		args.push('--project', project);
 	}
 	if (build) {
-		args.push('--build', build);
+		args.unshift('--build', build);
 	}
 	try {
 		await exec('node', args);


### PR DESCRIPTION
When providing the "build" option to TSC, the `--build` argument has to be the first argument provided, so instead of pushing it to the end of the array, it should be unshifted to the front instead.

```
Run icrawl/action-tsc@v1
  with:
    build: src
  env:
    GITHUB_TOKEN: ***
Added matchers: 'tsc'. Problem matchers scan action output for known warning or error strings and report these inline.
/opt/hostedtoolcache/node/12.14.1/x64/bin/node /home/runner/work/graphql-pokemon/graphql-pokemon/node_modules/typescript/bin/tsc --noEmit --noErrorTruncation --pretty false --build src
error TS6369: Option '--build' must be the first command line argument.
##[error]Node run failed with exit code 1
```