### PR TITLE
fix --build again

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ async function run() {
 		args.push('--project', project);
 	}
 	if (build) {
-		args.unshift('--build', build);
+		args.splice(1, 0, '--build', build);
 	}
 	try {
 		await exec('node', args);


### PR DESCRIPTION
This ***should*** work. This time I actually tested, in browser console:

```js
let args2 = [
		'node_modules/typescript/bin/tsc',
		'--noEmit',
		'--noErrorTruncation',
		'--pretty',
		'false',
	];

args2.splice(1,0,'--build', 'src')

console.log(args2)
(7) ["node_modules/typescript/bin/tsc", "--build", "src", "--noEmit", "--noErrorTruncation", "--pretty", "false"]