### PR TITLE
final fix for --build

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ async function run() {
 	}
 	if (build) {
 		args.splice(1, 0, '--build', build);
+		args.splice(3,2); // Remove --noEmit and --noErrorTruncation, which are unsupported with --build
 	}
 	try {
 		await exec('node', args);


### PR DESCRIPTION
*big sigh*, well this should **finally** do it. 

*note to future self: always test code, in all ways*

Running the command locally:
```sh
$ tsc -b src --noEmit --noErrorTruncation --pretty false
error TS5072: Unknown build option '--noEmit'.
error TS5072: Unknown build option '--noErrorTruncation'.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

$ tsc -b src --pretty false
Done in 14.80s.
# Yay it passed! 
```

And the splices performed in browser console:
```js
let args = [
		'node_modules/typescript/bin/tsc',
		'--noEmit',
		'--noErrorTruncation',
		'--pretty',
		'false',
];

console.log(args) // ["node_modules/typescript/bin/tsc", "--noEmit", "--noErrorTruncation", "--pretty", "false"]

args.splice(1,0,'--build', 'src') // []

console.log(args) // ["node_modules/typescript/bin/tsc", "--build", "src", "--noEmit", "--noErrorTruncation", "--pretty", "false"]

args.splice(3,2) // ["--noEmit", "--noErrorTruncation"]

console.log(args) // ["node_modules/typescript/bin/tsc", "--build", "src", "--pretty", "false"]

// ^ output is essentially identical to locally ran "tsc -b src --pretty false" ^
```