### PR TITLE
fix: TS3.8 errors when having both "incremental" and "noEmit"

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,8 @@ async function run() {
 		'--noErrorTruncation',
 		'--pretty',
 		'false',
+		'--incremental',
+		'false',
 	];
 	if (project) {
 		args.push('--project', project);
@@ -20,6 +22,8 @@ async function run() {
 		args.splice(1, 0, '--build', build);
 		// Remove --noEmit and --noErrorTruncation, which are unsupported with --build
 		args.splice(3, 2);
+		// Change --incremental false for --incremental true, as incremental builds are required for composite builds
+		args.splice(-1, 1, 'true');
 	}
 	try {
 		await exec('node', args);


### PR DESCRIPTION
```sh
Run icrawl/action-tsc@v1
Added matchers: 'tsc'. Problem matchers scan action output for known warning or error strings and report these inline.
/opt/hostedtoolcache/node/12.16.1/x64/bin/node /home/runner/work/nintendo-switch-eshop/nintendo-switch-eshop/node_modules/typescript/bin/tsc --noEmit --noErrorTruncation --pretty false
error TS5053: Option 'noEmit' cannot be specified with option 'incremental'.
```

This is new for TS3.8

` ./node_modules/typescript/bin/tsc --noEmit --noErrorTruncation --pretty false --incremental false` passed locally

And the same test block for `--build` as previous PR:
```js
let args = [
  "node_modules/typescript/bin/tsc",
  "--noEmit",
  "--noErrorTruncation",
  "--pretty",
  "false",
  "--incremental",
  "false"
];

console.log(args); // ["node_modules/typescript/bin/tsc", "--noEmit", "--noErrorTruncation", "--pretty", "false", "--incremental", "false"]

args.splice(1, 0, "--build", "src"); // []

console.log(args); // ["node_modules/typescript/bin/tsc", "--build", "src", "--noEmit", "--noErrorTruncation", "--pretty", "false", "--incremental", "false"]

args.splice(3, 2); // ["--noEmit", "--noErrorTruncation"]

console.log(args); // ["node_modules/typescript/bin/tsc", "--build", "src", "--pretty", "false", "--incremental", "false"]

args.splice(-1, 1, "true"); // ["false"]

console.log(args); // ["node_modules/typescript/bin/tsc", "--build", "src", "--pretty", "false", "--incremental", "true"]

console.log(args.join(" ")); // node_modules/typescript/bin/tsc --build src --pretty false --incremental true
```