### PR TITLE
doc: `--project` and package.json workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,6 @@ jobs:
       uses: icrawl/action-tsc@v1
 ```
 
-### Adding `tsc`
-
-If you're using an IDE with direct TypeScript support (such as Visual Studio) and don't have a dependency in your `package.json` you can add it using `yarn` before `icrawl/action-tsc`:
-
-```yml
-    - name: yarn get tsc
-      run: yarn add typescript --dev
-```
-
 ### Passing command-line parameters to `tsc`
 
 You can pass the `--project` parameter to `tsc` if your `tsconfig.json` is not in the root of your project:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,26 @@ jobs:
       uses: icrawl/action-tsc@v1
 ```
 
+### Adding `tsc`
+
+If you're using an IDE with direct TypeScript support (such as Visual Studio) and don't have a dependency in your `package.json` you can add it using `yarn` before `icrawl/action-tsc`:
+
+```yml
+    - name: yarn get tsc
+      run: yarn add typescript --dev
+```
+
+### Passing command-line parameters to `tsc`
+
+You can pass the `--project` parameter to `tsc` if your `tsconfig.json` is not in the root of your project:
+
+```yml
+    - name: tsc compile
+      uses: iCrawl/action-tsc@v1
+      with:
+        project: subdirectorywith_tsconfig
+```
+
 ## Contributing
 
 1. Fork it!


### PR DESCRIPTION
It took some digging in the source to figure out that `--project` could be passed, is it worth mentioning supported flags in the readme?