### PR TITLE
Make things a bit more generic by allowing to override the `tsc` executable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   build:
     description: 'Optional build reference path.'
     required: false
+  executable:
+    description: 'Compilation Executable (tsc or ttsc)'
+    default: 'tsc'
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ async function run() {
 	const executable = getInput('executable');
 	console.log(`##[add-matcher]${join(__dirname, '..', '.github', 'tsc.json')}`);
 	const args = [
-		`${join(process.cwd(), 'node_modules/typescript/bin', executable)}`,
+		`${join(process.cwd(), 'node_modules/.bin', executable)}`,
 		'--noEmit',
 		'--noErrorTruncation',
 		'--pretty',

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,9 +5,10 @@ import { join } from 'path';
 async function run() {
 	const project = getInput('project');
 	const build = getInput('build');
+	const executable = getInput('executable');
 	console.log(`##[add-matcher]${join(__dirname, '..', '.github', 'tsc.json')}`);
 	const args = [
-		`${join(process.cwd(), 'node_modules/typescript/bin/tsc')}`,
+		`${join(process.cwd(), 'node_modules/typescript/bin', executable)}`,
 		'--noEmit',
 		'--noErrorTruncation',
 		'--pretty',


### PR DESCRIPTION
My project uses `ttypescript` (https://github.com/cevek/ttypescript) which is a wrapper around the typescript compiler to add custom transforms. Since this action was just running `tsc` and then parsing the output .. I added a way to override the executable so it's easy to swap to use `ttsc` instead. I also had to switch from the specific package's bin folder to the generic `.bin` folder so this works smoothly.